### PR TITLE
EX raids eligibility map

### DIFF
--- a/monocle/static/js/raidex.js
+++ b/monocle/static/js/raidex.js
@@ -1,0 +1,157 @@
+var FortIcon = L.Icon.extend({
+    options: {
+        iconSize: [20, 20],
+        popupAnchor: [0, -10],
+        className: 'fort-icon'
+    }
+});
+
+var markers = {};
+var overlays = {
+    Gyms: L.layerGroup([]),
+    Parks: L.layerGroup([]),
+    Cells: L.layerGroup([]),
+    ScanArea: L.layerGroup([])
+};
+
+function unsetHidden (event) {
+    event.target.hidden = false;
+}
+
+function setHidden (event) {
+    event.target.hidden = true;
+}
+
+function monitor (group, initial) {
+    group.hidden = initial;
+    group.on('add', unsetHidden);
+    group.on('remove', setHidden);
+}
+
+monitor(overlays.Gyms, true)
+
+function FortMarker (raw) {
+    var icon = new FortIcon({iconUrl: '/static/monocle-icons/forts/' + raw.team + '.png'});
+    var marker = L.marker([raw.lat, raw.lon], {icon: icon, opacity: 1});
+    marker.raw = raw;
+    markers[raw.id] = marker;
+    marker.on('popupopen',function popupopen (event) {
+        var content = ''
+        content += '<br>=&gt; <a href=https://www.google.com/maps/?daddr='+ raw.lat + ','+ raw.lon +' target="_blank" title="See in Google Maps">Get directions</a>';
+        event.popup.setContent(content);
+    });
+    marker.bindPopup();
+    return marker;
+}
+
+function addGymsToMap (data, map) {
+    data.forEach(function (item) {
+        // No change since last time? Then don't do anything
+        var existing = markers[item.id];
+        if (typeof existing !== 'undefined') {
+            if (existing.raw.sighting_id === item.sighting_id) {
+                return;
+            }
+            existing.removeFrom(overlays.Gyms);
+            markers[item.id] = undefined;
+        }
+        marker = FortMarker(item);
+        marker.addTo(overlays.Gyms);
+    });
+}
+
+function addParksToMap (data, map) {
+    data.forEach(function (item) {
+        L.polygon(item.coords, {'color': 'limegreen'}).addTo(overlays.Parks);
+    });
+}
+
+function addCellsToMap (data, map) {
+    data.forEach(function (item) {
+        L.polygon(item.coords, {'color': 'grey'}).addTo(overlays.Cells);
+    });
+}
+
+function addScanAreaToMap (data, map) {
+    data.forEach(function (item) {
+        if (item.type === 'scanarea'){
+            L.polyline(item.coords).addTo(overlays.ScanArea);
+        } else if (item.type === 'scanblacklist'){
+            L.polyline(item.coords, {'color':'red'}).addTo(overlays.ScanArea);
+        }
+    });
+}
+
+function getGyms() {
+    if (overlays.Gyms.hidden) {
+        return;
+    }
+    new Promise(function (resolve, reject) {
+        $.get('/gym_data', function (response) {
+            resolve(response);
+        });
+    }).then(function (data) {
+        addGymsToMap(data, map);
+    });
+}
+
+function getParks() {
+    if (overlays.Parks.hidden) {
+        return;
+    }
+    new Promise(function (resolve, reject) {
+        $.get('/parks', function (response) {
+            resolve(response);
+        });
+    }).then(function (data) {
+        addParksToMap(data, map);
+    });
+}
+
+function getCells() {
+    if (overlays.Cells.hidden) {
+        return;
+    }
+    new Promise(function (resolve, reject) {
+        $.get('/cells', function (response) {
+            resolve(response);
+        });
+    }).then(function (data) {
+        addCellsToMap(data, map);
+    });
+}
+
+function getScanAreaCoords() {
+    new Promise(function (resolve, reject) {
+        $.get('/scan_coords', function (response) {
+            resolve(response);
+        });
+    }).then(function (data) {
+        addScanAreaToMap(data, map);
+    });
+}
+
+var map = L.map('main-map', {preferCanvas: true}).setView(_MapCoords, 13);
+
+overlays.ScanArea.addTo(map);
+
+var control = L.control.layers(null, overlays).addTo(map);
+L.tileLayer(_MapProviderUrl, {
+    opacity: 0.75,
+    attribution: _MapProviderAttribution
+}).addTo(map);
+map.whenReady(function () {
+    $('.my-location').on('click', function () {
+        map.locate({ enableHighAccurracy: true, setView: true });
+    });
+    overlays.Gyms.once('add', function(e) {
+        getGyms();
+    })
+    overlays.Parks.once('add', function(e) {
+        getParks();
+    })
+    overlays.Cells.once('add', function(e) {
+        getCells();
+    })
+    getScanAreaCoords();
+});

--- a/monocle/templates/raidex.html
+++ b/monocle/templates/raidex.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Monocle - {{ area_name }}</title>
+  <link rel="stylesheet" href='static/css/leaflet.css'>
+  <link rel="stylesheet" href='static/css/bootstrap.min.css'>
+  <link rel="stylesheet" href='static/css/main.css'>
+  <link rel="apple-touch-icon" sizes="180x180" href="/static/favicon/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/static/favicon/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/static/favicon/favicon-16x16.png">
+  <link rel="manifest" href="/static/favicon/manifest.json">
+  <link rel="mask-icon" href="/static/favicon/safari-pinned-tab.svg" color="#772c30">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <meta name="theme-color" content="#772c30">
+</head>
+<body>
+  <h1>Monocle is initializing, please wait.</h1>
+  <script>
+        var _MapCoords = [{{ map_center[0] }}, {{ map_center[1] }}];
+        var _MapProviderUrl = '{{ map_provider_url }}';
+        var _MapProviderAttribution = '{{ map_provider_attribution|safe }}';
+        _defaultSettings = {};
+        _updateTimeInterval = null;
+  </script>
+  <div id="main-map" class="map"></div>
+  <a class="map_btn my-location"></a>
+  <script>{{ init_js_vars }}</script>
+  <script src='static/js/jquery-3.2.1.min.js'></script>
+  <script src='static/js/leaflet.js'></script>
+  <script src='static/js/bootstrap.min.js'></script>
+  <script src='static/js/raidex.js'></script>
+  {{ extra_css_js }}
+</body>
+</html>

--- a/monocle/web_utils.py
+++ b/monocle/web_utils.py
@@ -5,10 +5,13 @@ from time import time
 
 from monocle import sanitized as conf
 from monocle.db import get_forts, Pokestop, session_scope, Sighting, Spawnpoint, Raid, Fort, FortSighting, Weather
-from monocle.utils import Units, get_address
+from monocle.utils import Units, get_address, dump_pickle, load_pickle
 from monocle.names import DAMAGE, MOVES, POKEMON
+from monocle.bounds import north, south, east, west
 
 import s2sphere
+import overpy
+from shapely.geometry import Polygon, Point
 
 if conf.MAP_WORKERS:
     try:
@@ -246,4 +249,42 @@ def sighting_to_report_marker(sighting):
         'lat': sighting.lat,
         'lon': sighting.lon,
     }
+
+def get_all_parks():
+    parks = []
+    try:
+        parks = load_pickle('parks', raise_exception=True)
+    except (FileNotFoundError, TypeError, KeyError):
+        # all osm parks at 10/07/2016
+        api = overpy.Overpass()
+        request = '[timeout:620][date:"2016-07-10T00:00:00Z"];(way["leisure"="park"];way["landuse"="recreation_ground"];way["leisure"="recreation_ground"];way["leisure"="pitch"];way["leisure"="garden"];way["leisure"="golf_course"];way["leisure"="playground"];way["landuse"="meadow"];way["landuse"="grass"];way["landuse"="greenfield"];way["natural"="scrub"];);out;>;out skel qt;'
+        request = '[bbox:{},{},{},{}]{}'.format(south, west, north, east, request)
+        response = api.query(request)
+        for w in response.ways:
+            parks.append({
+                'type': 'park',
+                'coords': [[float(c.lat), float(c.lon)] for c in w.nodes]
+            })
+        dump_pickle('parks', parks)
+    
+    return parks
+
+def get_s2_cells(level=12):
+    region_covered = s2sphere.LatLngRect.from_point_pair(
+        s2sphere.LatLng.from_degrees(north, west),
+        s2sphere.LatLng.from_degrees(south, east)
+    )
+    coverer = s2sphere.RegionCoverer()
+    coverer.min_level = level
+    coverer.max_level = level
+    coverer.max_cells = 50
+    covering = coverer.get_covering(region_covered)
+    markers = []
+    for cellid in covering:
+        cell = s2sphere.Cell(cellid)
+        markers.append({
+            'id': 'cell-' + str(cellid.id()),
+            'coords': [(get_vertex(cell, v)) for v in range(0, 4)]
+        })
+    return markers
 

--- a/raidex.py
+++ b/raidex.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+
+from datetime import datetime
+from pkg_resources import resource_filename
+
+try:
+    from ujson import dumps
+    from flask import json as flask_json
+    flask_json.dumps = lambda obj, **kwargs: dumps(obj, double_precision=6)
+except ImportError:
+    from json import dumps
+
+from flask import Flask, jsonify, Markup, render_template, request
+
+from monocle import db, sanitized as conf
+from monocle.web_utils import *
+from monocle.bounds import area, center
+
+from shapely.geometry import Polygon, Point
+
+
+app = Flask(__name__, template_folder=resource_filename('monocle', 'templates'), static_folder=resource_filename('monocle', 'static'))
+
+def render_map():
+    template = app.jinja_env.get_template('raidex.html')
+    return template.render(
+        area_name=conf.AREA_NAME,
+        map_center=center,
+        map_provider_url=conf.MAP_PROVIDER_URL,
+        map_provider_attribution=conf.MAP_PROVIDER_ATTRIBUTION
+    )
+    
+@app.route('/')
+def fullmap(map_html=render_map()):
+    return map_html
+
+@app.route('/gym_data')
+def gym_data():
+    gyms = []
+    parks = get_all_parks()
+    for g in get_gym_markers():
+        for p in parks:
+            if Polygon(p['coords']).contains(Point(g['lat'], g['lon'])):
+                gyms.append(g)
+    return jsonify(gyms)
+
+@app.route('/parks')
+def parks():
+    return jsonify(get_all_parks())
+
+@app.route('/cells')
+def cells():
+    return jsonify(get_s2_cells())
+
+@app.route('/scan_coords')
+def scan_coords():
+    return jsonify(get_scan_coords())
+
+def main():
+    args = get_args()
+    app.run(debug=args.debug, threaded=True, host=args.host, port=args.port)
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ aiohttp>=2.1,<2.3
 pogeo==0.3.*
 cyrandom>=0.1.2
 s2sphere>=0.2.5
+overpy>=0.4


### PR DESCRIPTION
quick flask webpage displaying for boundaries of a monocle map
- s2 lvl 10 cells
- parks (request on OSM and cached in pickle)
- eligible gyms (only in parks for now)
python3 raidex.py (-P your_port -H your_host)